### PR TITLE
Add new properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 ![GitHub code size](https://img.shields.io/github/languages/code-size/chandrabezzo/CountryCodePicker)
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 ![GitHub contributors](https://img.shields.io/github/contributors/chandrabezzo/CountryCodePicker)
 [![Pub](https://img.shields.io/pub/v/country_code_picker.svg)](https://pub.dartlang.org/packages/country_code_picker)
 [![Linkedin](https://i.stack.imgur.com/gVE0j.png) LinkedIn](https://www.linkedin.com/in/salvatore-giordano/)
@@ -138,54 +142,61 @@ Just add the `CountryLocalizations.delegate` in the list of your app delegates
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
       ],
+ )
 ```
 
 ## Customization
 
 Here is a list of properties available to customize your widget:
 
-| Name | Type | Description |
-|-----|-----|------|
-|onChanged| ValueChanged<CountryCode> | callback invoked when the selection changes |
-|onInit| ValueChanged<CountryCode> | callback invoked during initialization of the widget |
-|initialSelection| String | used to set the initial selected value |
-|favorite| List<String> | used to populate the favorite country list |
-|textStyle| TextStyle | TextStyle applied to the widget button |
-|padding| EdgeInsetsGeometry | the padding applied to the button |
-|showCountryOnly| bool | true if you want to see only the countries in the selection dialog |
-|searchDecoration| InputDecoration | decoration applied to the TextField search widget |
-|searchStyle| TextStyle | style applied to the TextField search widget text |
-|emptySearchBuilder| WidgetBuilder | use this to customize the widget used when the search returns 0 elements |
-|builder| Function(CountryCode) | use this to build a custom widget instead of the default FlatButton |
-|enabled| bool | set to false to disable the widget |
-|textOverflow| TextOverflow | the button text overflow behaviour |
-|dialogSize| Size | the size of the selection dialog |
-|countryFilter| List<String> | uses a list of strings to filter a sublist of countries |
-|showOnlyCountryWhenClosed| bool | if true it'll show only the country |
-|alignLeft| bool | aligns the flag and the Text to the left |
-|showFlag| bool | shows the flag everywhere |
-|showFlagMain| bool | shows the flag only when closed |
-|showFlagDialog| bool | shows the flag only in dialog |
-|flagWidth| double | the width of the flags |
-|flagDecoration| Decoration | used for styling the flags |
-|comparator| Comparator<CountryCode> | use this to sort the countries in the selection dialog |
-|hideSearch| bool | if true the search feature will be disabled |
+| Name                      | Type                      | Description                                                              |
+| ------------------------- | ------------------------- | ------------------------------------------------------------------------ |
+| alignLeft                 | bool                      | aligns the flag and the Text to the left                                 |
+| builder                   | Function(CountryCode)     | use this to build a custom widget instead of the default FlatButton      |
+| closeIcon                 | Widget                    | custom widget used to close the dialog                                   |
+| comparator                | Comparator<CountryCode>   | use this to sort the countries in the selection dialog                   |
+| countryFilter             | List<String>              | uses a list of strings to filter a sublist of countries                  |
+| dialogSize                | Size                      | the size of the selection dialog                                         |
+| dialogTitle               | Widget                    | custom widget used as title for the dialog.                              |
+| emptySearchBuilder        | WidgetBuilder             | use this to customize the widget used when the search returns 0 elements |
+| enabled                   | bool                      | set to false to disable the widget                                       |
+| favorites                 | List<String>              | used to populate the favorite country list                               |
+| flagDecoration            | Decoration                | used for styling the flags                                               |
+| flagWidth                 | double                    | the width of the flags                                                   |
+| hideSearch                | bool                      | if true, the search feature will be disabled                             |
+| initialSelection          | String                    | used to set the initial selected value                                   |
+| onChanged                 | ValueChanged<CountryCode> | callback invoked when the selection changes                              |
+| onInit                    | ValueChanged<CountryCode> | callback invoked during initialization of the widget                     |
+| padding                   | EdgeInsetsGeometry        | the padding applied to the button                                        |
+| searchDecoration          | InputDecoration           | decoration applied to the TextField search widget                        |
+| searchStyle               | TextStyle                 | style applied to the TextField search widget text                        |
+| separator                 | Widget                    | separator widget for list items inside the dialog                        |
+| showCountryOnly           | bool                      | true if you want to see only the countries in the selection dialog       |
+| showFlag                  | bool                      | shows the flag everywhere                                                |
+| showFlagsInDialog         | bool                      | shows the flag only in dialog                                            |
+| showFlagMain              | bool                      | shows the flag only when the dialog closed                               |
+| showOnlyCountryWhenClosed | bool                      | if true, it'll show only the country                                     |
+| textOverflow              | TextOverflow              | the button text overflow behaviour                                       |
+| textStyle                 | TextStyle                 | textStyle applied to the widget button                                   |
 
 ## Contributions
 
 Contributions of any kind are more than welcome! Feel free to fork and improve country_code_picker in any way you want, make a pull request, or open an issue.
 
-
 ## Getting involved
-First of all, thank you for even considering to get involved. You are a real super :star:  and we :heart:  you!
+
+First of all, thank you for even considering to get involved. You are a real super :star: and we :heart: you!
 
 ### Reporting bugs and issues
+
 Use the configured [Github issue report template](https://github.com/imtoori/CountryCodePicker/issues/new?assignees=&labels=&template=bug_report.md&title=) when reporting an issue. Make sure to state your observations and expectations
 as objectively and informative as possible so that we can understand your need and be able to troubleshoot.
 
 ### Discussions and ideas
+
 We're happy to discuss and talk about ideas, post your
 question to [StackOverflow](https://stackoverflow.com/search?q=country+code+picker).
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key key}) : super(key: key);
+  const MyApp({Key? key}) : super(key: key);
 
   @override
   MyAppState createState() => MyAppState();
@@ -102,21 +102,27 @@ class MyAppState extends State<MyApp> {
             children: <Widget>[
               CountryCodePicker(
                 onChanged: print,
-                // Initial selection and favorite can be one of code ('IT') OR dial_code('+39')
+                // Initial selection and favorites can be one of code ('IT') OR dial_code('+39')
                 initialSelection: 'IT',
-                favorite: const ['+39', 'FR'],
+                separator: const Divider(height: 0),
+                dialogTitle: const Padding(
+                  padding: EdgeInsets.only(left: 24.0),
+                  child: Text(
+                    'Dialog title',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                ),
                 countryFilter: const ['IT', 'FR'],
-                showFlagDialog: false,
-                comparator: (a, b) => b.name.compareTo(a.name),
+                comparator: (a, b) => b.name!.compareTo(a.name!),
                 //Get the country information relevant to the initial selection
                 onInit: (code) => debugPrint(
-                    "on init ${code.name} ${code.dialCode} ${code.name}"),
+                    "on init ${code!.name} ${code.dialCode} ${code.name}"),
               ),
               CountryCodePicker(
                 onChanged: print,
-                // Initial selection and favorite can be one of code ('IT') OR dial_code('+39')
+                // Initial selection and favorites can be one of code ('IT') OR dial_code('+39')
                 initialSelection: 'IT',
-                favorite: const ['+39', 'FR'],
+                favorites: const ['+39', 'FR'],
                 countryFilter: const ['IT', 'FR'],
                 // flag can be styled with BoxDecoration's `borderRadius` and `shape` fields
                 flagDecoration: BoxDecoration(
@@ -146,7 +152,7 @@ class MyAppState extends State<MyApp> {
                   initialSelection: 'TF',
                   showCountryOnly: true,
                   showOnlyCountryWhenClosed: true,
-                  favorite: const ['+39', 'FR'],
+                  favorites: const ['+39', 'FR'],
                 ),
               ),
               SizedBox(
@@ -158,7 +164,7 @@ class MyAppState extends State<MyApp> {
                   initialSelection: 'TF',
                   showCountryOnly: true,
                   showOnlyCountryWhenClosed: true,
-                  favorite: const ['+39', 'FR'],
+                  favorites: const ['+39', 'FR'],
                 ),
               ),
             ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/lib/country_code_picker.dart
+++ b/lib/country_code_picker.dart
@@ -13,83 +13,121 @@ export 'src/country_localizations.dart';
 export 'src/selection_dialog.dart';
 
 class CountryCodePicker extends StatefulWidget {
+  /// Callback invoked when the selection changes.
   final ValueChanged<CountryCode>? onChanged;
-  final ValueChanged<CountryCode?>? onInit;
-  final String? initialSelection;
-  final List<String> favorite;
-  final TextStyle? textStyle;
-  final EdgeInsetsGeometry padding;
-  final bool showCountryOnly;
-  final InputDecoration searchDecoration;
-  final TextStyle? searchStyle;
-  final TextStyle? dialogTextStyle;
-  final WidgetBuilder? emptySearchBuilder;
-  final Function(CountryCode?)? builder;
-  final bool enabled;
-  final TextOverflow textOverflow;
-  final Icon closeIcon;
 
-  /// Barrier color of ModalBottomSheet
+  /// Callback invoked during initialization of the widget.
+  final ValueChanged<CountryCode?>? onInit;
+
+  /// Used to set the initial selected value.
+  final String? initialSelection;
+
+  /// Used to populate the favorite country list.
+  final List<String> favorites;
+
+  /// TextStyle applied to the widget button.
+  final TextStyle? textStyle;
+
+  /// The padding applied to the button.
+  final EdgeInsetsGeometry padding;
+
+  /// When true, the dialog will not show the dial code, only the country name.
+  final bool showCountryOnly;
+
+  /// The input decoration for the search field in the dialog.
+  final InputDecoration searchDecoration;
+
+  /// The TextStyle of the search field.
+  final TextStyle? searchStyle;
+
+  /// The TextStyle of the country name and country code in the dialog.
+  final TextStyle? dialogTextStyle;
+
+  /// Use this to customize the widget used when the search returns 0 elements.
+  final WidgetBuilder? emptySearchBuilder;
+
+  /// Use this to build a custom widget instead of the default FlatButton.
+  final Function(CountryCode?)? builder;
+
+  /// Set to false to disable the widget.
+  final bool enabled;
+
+  /// The button text overflow behaviour.
+  final TextOverflow textOverflow;
+
+  /// Custom widget used to close the dialog.
+  final Widget? closeIcon;
+
+  /// Custom widget used as title for the dialog.
+  final Widget? dialogTitle;
+
+  /// Barrier color of ModalBottomSheet.
   final Color? barrierColor;
 
-  /// Background color of ModalBottomSheet
+  /// Background color of ModalBottomSheet.
   final Color? backgroundColor;
 
-  /// BoxDecoration for dialog
+  /// BoxDecoration for dialog.
   final BoxDecoration? boxDecoration;
 
-  /// the size of the selection dialog
+  /// the size of the selection dialog.
   final Size? dialogSize;
 
-  /// Background color of selection dialog
+  /// Background color of selection dialog.
   final Color? dialogBackgroundColor;
 
-  /// used to customize the country list
+  /// used to customize the country list.
   final List<String>? countryFilter;
 
-  /// shows the name of the country instead of the dialcode
+  /// shows the name of the country instead of the dialcode.
   final bool showOnlyCountryWhenClosed;
 
   /// aligns the flag and the Text left
   ///
   /// additionally this option also fills the available space of the widget.
   /// this is especially useful in combination with [showOnlyCountryWhenClosed],
-  /// because longer country names are displayed in one line
+  /// because longer country names are displayed in one line.
   final bool alignLeft;
 
-  /// shows the flag
+  /// Whether to show the flag on the button or not.
   final bool showFlag;
 
+  /// When true, the button does not display the country code nor the country name.
   final bool hideMainText;
 
+  /// Shows the flag only when the dialog closed.
   final bool? showFlagMain;
 
-  final bool? showFlagDialog;
+  /// Whether to show flags in the dialog or not.
+  final bool? showFlagsInDialog;
 
-  /// Width of the flag images
+  /// Width of the flag images.
   final double flagWidth;
 
-  /// Use this property to change the order of the options
+  /// Use this property to change the order of the options.
   final Comparator<CountryCode>? comparator;
 
-  /// Set to true if you want to hide the search part
+  /// Set to true if you want to hide the search part.
   final bool hideSearch;
 
-  /// Set to true if you want to show drop down button
+  /// Set to true if you want to show drop down button.
   final bool showDropDownButton;
 
-  /// [BoxDecoration] for the flag image
+  /// [BoxDecoration] for the flag image.
   final Decoration? flagDecoration;
 
   /// An optional argument for injecting a list of countries
   /// with customized codes.
   final List<Map<String, String>> countryList;
 
+  /// Separator widget for list items inside the dialog.
+  final Widget? separator;
+
   const CountryCodePicker({
     this.onChanged,
     this.onInit,
     this.initialSelection,
-    this.favorite = const [],
+    this.favorites = const [],
     this.textStyle,
     this.padding = const EdgeInsets.all(8.0),
     this.showCountryOnly = false,
@@ -100,7 +138,7 @@ class CountryCodePicker extends StatefulWidget {
     this.showOnlyCountryWhenClosed = false,
     this.alignLeft = false,
     this.showFlag = true,
-    this.showFlagDialog,
+    this.showFlagsInDialog,
     this.hideMainText = false,
     this.showFlagMain,
     this.flagDecoration,
@@ -117,8 +155,10 @@ class CountryCodePicker extends StatefulWidget {
     this.showDropDownButton = false,
     this.dialogSize,
     this.dialogBackgroundColor,
-    this.closeIcon = const Icon(Icons.close),
+    this.closeIcon,
+    this.dialogTitle,
     this.countryList = codes,
+    this.separator,
     Key? key,
   }) : super(key: key);
 
@@ -276,7 +316,7 @@ class CountryCodePickerState extends State<CountryCodePicker> {
 
     favoriteElements = elements
         .where((item) =>
-            widget.favorite.firstWhereOrNull((criteria) =>
+            widget.favorites.firstWhereOrNull((criteria) =>
                 item.code!.toUpperCase() == criteria.toUpperCase() ||
                 item.dialCode == criteria ||
                 item.name!.toUpperCase() == criteria.toUpperCase()) !=
@@ -299,14 +339,16 @@ class CountryCodePickerState extends State<CountryCodePicker> {
             searchStyle: widget.searchStyle,
             textStyle: widget.dialogTextStyle,
             boxDecoration: widget.boxDecoration,
-            showFlag: widget.showFlagDialog ?? widget.showFlag,
+            showFlag: widget.showFlagsInDialog ?? widget.showFlag,
             flagWidth: widget.flagWidth,
             size: widget.dialogSize,
             backgroundColor: widget.dialogBackgroundColor,
             barrierColor: widget.barrierColor,
             hideSearch: widget.hideSearch,
             closeIcon: widget.closeIcon,
+            title: widget.dialogTitle,
             flagDecoration: widget.flagDecoration,
+            separator: widget.separator,
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.15.0
+  flutter_localizations:
+    sdk: flutter
+  intl: any
 
 flutter:
   assets:


### PR DESCRIPTION
Changes made:

1. Added two new fields (`dialogTitle` and `separator`)
2. Converted `closeIcon` to Widget so that it may be customizable
3. Updated results tiles in the dialog to show dial code on the far right-hand side
4. Updated the _customization_ section of the readme to incorporate these changes. Also sorted the properties alphabetically to make it easier to find a particular item
5. Updated the example folder to demonstrate the new properties.