### PR TITLE
Hide dialog close icon

### DIFF
--- a/lib/country_code_picker.dart
+++ b/lib/country_code_picker.dart
@@ -75,6 +75,9 @@ class CountryCodePicker extends StatefulWidget {
   /// Set to true if you want to hide the search part
   final bool hideSearch;
 
+  /// Set to true if you want to hide the close icon dialog
+  final bool hideCloseIcon;
+
   /// Set to true if you want to show drop down button
   final bool showDropDownButton;
 
@@ -114,6 +117,7 @@ class CountryCodePicker extends StatefulWidget {
     this.comparator,
     this.countryFilter,
     this.hideSearch = false,
+    this.hideCloseIcon = false,
     this.showDropDownButton = false,
     this.dialogSize,
     this.dialogBackgroundColor,
@@ -305,6 +309,7 @@ class CountryCodePickerState extends State<CountryCodePicker> {
             backgroundColor: widget.dialogBackgroundColor,
             barrierColor: widget.barrierColor,
             hideSearch: widget.hideSearch,
+            hideCloseIcon: widget.hideCloseIcon,
             closeIcon: widget.closeIcon,
             flagDecoration: widget.flagDecoration,
           ),

--- a/lib/src/selection_dialog.dart
+++ b/lib/src/selection_dialog.dart
@@ -17,6 +17,7 @@ class SelectionDialog extends StatefulWidget {
   final Decoration? flagDecoration;
   final Size? size;
   final bool hideSearch;
+  final bool hideCloseIcon;
   final Icon? closeIcon;
 
   /// Background color of SelectionDialog
@@ -45,6 +46,7 @@ class SelectionDialog extends StatefulWidget {
     this.backgroundColor,
     this.barrierColor,
     this.hideSearch = false,
+    this.hideCloseIcon = false,
     this.closeIcon,
   })  : searchDecoration = searchDecoration.prefixIcon == null
             ? searchDecoration.copyWith(prefixIcon: const Icon(Icons.search))
@@ -84,6 +86,7 @@ class _SelectionDialogState extends State<SelectionDialog> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
+              if (!widget.hideCloseIcon)
               IconButton(
                 padding: const EdgeInsets.all(0),
                 iconSize: 20,


### PR DESCRIPTION
Introduced a new parameter, hideCloseIcon, for both the CountryCodePicker and SelectionDialog widgets. When this parameter is set to true, the close icon in the dialog will not appear.